### PR TITLE
Since we're using a fileresource for init.d/snmpd no operating specific   rls sysconfig is required

### DIFF
--- a/files/etc/sysconfig/snmpd
+++ b/files/etc/sysconfig/snmpd
@@ -2,5 +2,5 @@
 # DO NOT EDIT
 
 # snmpd command line options
-OPTIONS="-LS0-4d -Lf /dev/null -p /var/run/snmpd.pid -a"
+OPTIONS="-Ls d -Lf /dev/null -p /var/run/snmpd.pid -a"
 SNMPCUSTCONFPATH="/etc/snmp/include"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,10 +16,7 @@
 #
 class snmp($syslocation = '', $syscontact = '', $additional_config = '') {
 
-  $snmpd_options_file = $::operatingsystemrelease ? {
-    /^5.*$/ => '/etc/sysconfig/snmpd.options',
-    /^6.*$/ => '/etc/sysconfig/snmpd',
-  }
+  $snmpd_options_file = '/etc/sysconfig/snmpd'
 
   package { ['net-snmp', 'net-snmp-utils'] :
     ensure  => present,


### PR DESCRIPTION
...fiek sysconfig is required
